### PR TITLE
Fix: Terminates if empty line is read.

### DIFF
--- a/anonip.py
+++ b/anonip.py
@@ -8,7 +8,7 @@ https://www.digitale-gesellschaft.ch.
 Special thanks to: Thomas B. and Fabio R.
 
 Copyright (c) 2013 - 2016, Swiss Privacy Foundation
-              2016 - 2018, Digitale Gesellschaft
+              2016 - 2019, Digitale Gesellschaft
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/anonip.py
+++ b/anonip.py
@@ -104,22 +104,8 @@ class Anonip(object):
 
         :return: None
         """
-        while 1:
-            try:
-                line = sys.stdin.readline()
-            except IOError as err:  # pragma: no cover
-                # if reading from stdin fails, exit
-                logger.warning(err)
-                break
-            except KeyboardInterrupt:  # pragma: no cover
-                break
-            else:
-                line = line.rstrip()
-
-            # if line couldn't be read (e.g. when EOF has been received)
-            # exit the loop
-            if not line:
-                break
+        for line in sys.stdin:
+            line = line.rstrip()
 
             logger.debug("Got line: {}".format(line))
 

--- a/tests.py
+++ b/tests.py
@@ -166,12 +166,11 @@ class TestAnonipClass(unittest.TestCase):
         )
 
     def test_run(self):
-        sys.stdin = StringIO("192.168.100.200\n1.2.3.4\n\n")
+        sys.stdin = StringIO("192.168.100.200\n1.2.3.4\n  \n9.8.130.6\n")
         lines = []
         for line in self.anonip.run():
             lines.append(line)
-        self.assertEqual(lines[0], "192.168.96.0")
-        self.assertEqual(lines[1], "1.2.0.0")
+        assert lines == ["192.168.96.0", "1.2.0.0"]
 
 
 class TestAnonipCli(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -170,7 +170,12 @@ class TestAnonipClass(unittest.TestCase):
         lines = []
         for line in self.anonip.run():
             lines.append(line)
-        assert lines == ["192.168.96.0", "1.2.0.0"]
+        assert lines == [
+            "192.168.96.0",
+            "1.2.0.0",
+            "",  # all-white-space line
+            "9.8.128.0",
+        ]
 
 
 class TestAnonipCli(unittest.TestCase):


### PR DESCRIPTION
This code
https://github.com/DigitaleGesellschaft/Anonip/blob/b0d168ec4a223f70374693ead40a696b6886bc28/anonip.py#L116-L122
will terminate the program if an empty line or a line containing only white-space is read.

I'm not sure whether this behavior was intended since the respective test-case does not actually test this. I added a test-case (2nd commit) for this so one can easily spot the behavior.

IMHO reading an empty or all-white-space line is unusual, but should not terminate the program. The program should only terminate on EOF (or on error).

3rd commit changes the behavior to not terminate in this case and adjusts the test-case so the difference can be spotted easily.