### PR TITLE
Tests: Make `black` output the diff it would apply.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps=
 commands=
     py{27,35,36,37}: python -m pytest --cov=anonip --cov-report=term-missing --no-cov-on-fail -r a tests.py anonip.py
     flake8: flake8 ./*.py
-    black: black --check ./
+    black: black --check --diff ./


### PR DESCRIPTION
This helps actually fixing the error, it travis tests fail.