### PR TITLE
Add option ``--input``

### DIFF
--- a/anonip.py
+++ b/anonip.py
@@ -379,17 +379,20 @@ def main():
         args.skip_private,
     )
 
-    if args.output:
-        try:
-            with open(args.output, "a") as output_file:
-                for line in anonip.run():
-                    print(line, file=output_file)
-                    output_file.flush()
-        except IOError as err:  # pragma: no cover
-            logger.error(err)
-    else:
+    output_file = None
+    try:
+        if args.output:
+            output_file = open(args.output, "a")
+        else:
+            output_file = sys.stdout
         for line in anonip.run():
-            print(line)
+            print(line, file=output_file)
+            output_file.flush()
+    except IOError as err:  # pragma: no cover
+        logger.error(err)
+    finally:
+        if args.output and output_file:
+            output_file.close()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/anonip.py
+++ b/anonip.py
@@ -387,6 +387,8 @@ def main():
             output_file = sys.stdout
         for line in anonip.run():
             print(line, file=output_file)
+            # TODO: when dropping support for Python <= 3.3, move the
+            # flush into the print()
             output_file.flush()
     except IOError as err:  # pragma: no cover
         logger.error(err)

--- a/anonip.py
+++ b/anonip.py
@@ -9,6 +9,7 @@ Special thanks to: Thomas B. and Fabio R.
 
 Copyright (c) 2013 - 2016, Swiss Privacy Foundation
               2016 - 2019, Digitale Gesellschaft
+              2019,        Hartmut Goebel
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/anonip.py
+++ b/anonip.py
@@ -120,7 +120,8 @@ class Anonip(object):
 
     def run(self, input_file=None):
         """
-        Generator that reads from stdin and loops forever.
+        Generator that reads from file handle (defaults to stdin)
+        and loops forever.
 
         Yields anonymized log lines.
 

--- a/anonip.py
+++ b/anonip.py
@@ -117,15 +117,20 @@ class Anonip(object):
         self._ipv6mask = mask
         self._prefixes[6] = 128 - mask
 
-    def run(self):
+    def run(self, input_file=None):
         """
         Generator that reads from stdin and loops forever.
 
         Yields anonymized log lines.
 
+        :param input_file: file handle to read from (default: sys.stdin)
         :return: None
         """
-        for line in sys.stdin:
+        if not input_file:
+            # Assign here instead of using a default parameter value
+            # to allow "late binding".
+            input_file = sys.stdin
+        for line in input_file:
             line = line.rstrip()
 
             logger.debug("Got line: %r", line)

--- a/anonip.py
+++ b/anonip.py
@@ -317,6 +317,9 @@ def parse_arguments(args):
     parser.set_defaults(increment=0)
     parser.add_argument("-o", "--output", metavar="FILE", help="file to write to")
     parser.add_argument(
+        "--input", metavar="FILE", help="File or FIFO to read from (default: stdin)"
+    )
+    parser.add_argument(
         "-c",
         "--column",
         metavar="INTEGER",
@@ -379,13 +382,15 @@ def main():
         args.skip_private,
     )
 
-    output_file = None
+    input_file = output_file = None
     try:
+        if args.input:
+            input_file = open(args.input, "r")
         if args.output:
             output_file = open(args.output, "a")
         else:
             output_file = sys.stdout
-        for line in anonip.run():
+        for line in anonip.run(input_file):
             print(line, file=output_file)
             # TODO: when dropping support for Python <= 3.3, move the
             # flush into the print()
@@ -393,6 +398,8 @@ def main():
     except IOError as err:  # pragma: no cover
         logger.error(err)
     finally:
+        if args.input and input_file:
+            input_file.close()
         if args.output and output_file:
             output_file.close()
 

--- a/tests.py
+++ b/tests.py
@@ -169,6 +169,15 @@ def test_run():
     assert lines == ["192.168.96.0", "1.2.0.0", "", "9.8.128.0"]
 
 
+def test_run_with_input_file():
+    a = anonip.Anonip()
+
+    input_file = StringIO("192.168.100.200\n1.2.3.4\n  \n9.8.130.6\n")
+
+    lines = [line for line in a.run(input_file)]
+    assert lines == ["192.168.96.0", "1.2.0.0", "", "9.8.128.0"]
+
+
 @pytest.mark.parametrize(
     "args,attribute,expected",
     [

--- a/tests.py
+++ b/tests.py
@@ -270,6 +270,26 @@ def test_main(to_file, debug, log_level, backup_and_restore_sys_argv, tmp_path):
     assert logger.level == log_level
 
 
+def test_main_reading_from_input_file(tmp_path, backup_and_restore_sys_argv):
+    input_filename = tmp_path / "anonip-input.txt"
+    input_filename.write_text(
+        "string;192.168.100.200\n"
+        "string;1.2.3.4\n"
+        "string;2001:0db8:85a3:0000:0000:8a2e:0370:7334\n"
+        "string;2a00:1450:400a:803::200e\n"
+        "string;string\n\n"
+    )
+    sys.argv = ["anonip.py", "--input", str(input_filename), "-d"]
+    with captured_output() as (out, err):
+        anonip.main()
+    lines = out.getvalue().split("\n")
+    assert lines[0] == "string;192.168.100.200"
+    assert lines[1] == "string;1.2.3.4"
+    assert lines[2] == "string;2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    assert lines[3] == "string;2a00:1450:400a:803::200e"
+    assert lines[4] == "string;string"
+
+
 def test_prefixes_dict():
     a = anonip.Anonip(ipv4mask=11, ipv6mask=83)
     prefixes = a._prefixes


### PR DESCRIPTION
This command-line option allows setting the input-stream the logs are read from.

This is required when starting anonip as a service using systemd:
- systemd unit-files do not allow `<` redirect in the `Exec*=…` line.
- Using `StandardInput=file:…` for redirecting [requires systemd v236](https://github.com/systemd/systemd/blob/v236/NEWS#L130), which is not available in Debian 9 (Stretch) which has LTS until 2022-06 (and Debian 10 is not yet released).

Using systemd for starting the anonip process simpifies using anonip with nginx *a lot*. I already prepared examples for respective systemd-unit files, but this still requires some testing.