### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE.txt
+include tests.py
+include tox.ini


### PR DESCRIPTION
This commit adds a MANIFEST.in in order to add following files to sdist:

 - LICENSE.txt
 - tests.py
 - tox.ini

LICENSE.txt should have been added already in
fd2e942dffd463a8ff344155fc857721c3f46251, but it seems that
`license_files` in `[metadata]` in setup.cfg is only read for wheels.

Closes #20
Related to #19