### PR TITLE
chore(tests): temporary limit the maximum version of isort

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ commands=pytest -r a -vv tests.py anonip.py
 deps=
     pytest
     flake8
+    # can be removed, once flake8-isort dependency is resolved (https://github.com/gforcada/flake8-isort/issues/88)
+    isort<5
     flake8-isort
     flake8-bugbear
 commands=flake8


### PR DESCRIPTION
This should be reverted once flake8-isort fixes the compatibility.