### PR TITLE
feat(cli): Regex based IP detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Using shell redirects, it's also possible to rewrite existing log files.
  - Masks IP addresses in log files
  - Configurable amount of masked bits
  - The column containing the IP address can freely be chosen
+ - Alternatively use a regex to point anonip to the location(s) of the IP(s). See [this RFC](https://github.com/DigitaleGesellschaft/Anonip/issues/44) for more information.
  - Works for both access.log- and error.log files
 
 ## Officially supported python versions
@@ -57,7 +58,7 @@ For python versions <3.3:
 ```
 usage: anonip.py [-h] [-4 INTEGER] [-6 INTEGER] [-i INTEGER] [-o FILE]
                  [--input FILE] [-c INTEGER [INTEGER ...]] [-l STRING]
-                 [-r STRING] [-p] [-d] [-v]
+                 [--regex STRING [STRING ...]] [-r STRING] [-p] [-d] [-v]
 
 Anonip is a tool to anonymize IP-addresses in log files.
 
@@ -77,6 +78,8 @@ optional arguments:
                         default: 1)
   -l STRING, --delimiter STRING
                         log delimiter (default: " ")
+  --regex STRING [STRING ...]
+                        regex for detecting IP addresses (use instead of -c)
   -r STRING, --replace STRING
                         replacement string in case address parsing fails
                         (Example: 0.0.0.0)
@@ -84,6 +87,9 @@ optional arguments:
                         Special-Purpose Address Registry.
   -d, --debug           print debug messages
   -v, --version         show program's version number and exit
+
+Example-usage in apache-config:
+CustomLog "| /path/to/anonip.py [OPTIONS] --output /path/to/log" combined
 ```
 
 ## Usage

--- a/tests.py
+++ b/tests.py
@@ -10,6 +10,7 @@ from __future__ import print_function, unicode_literals
 
 import argparse
 import logging
+import re
 import sys
 from io import StringIO
 
@@ -128,6 +129,54 @@ def test_column(line, columns, expected):
     assert a.process_line(line) == expected
 
 
+@pytest.mark.parametrize(
+    "line,regex,expected,replace",
+    [
+        (
+            '3.3.3.3 - - [20/May/2015:21:05:01 +0000] "GET / HTTP/1.1" 200 13358 "-" "useragent"',
+            re.compile(
+                r"(?:^([^,]+) - - |.* - somefixedstring: ([^,]+) - .* - ([^,]+))"
+            ),
+            '3.3.0.0 - - [20/May/2015:21:05:01 +0000] "GET / HTTP/1.1" 200 13358 "-" "useragent"',
+            None,
+        ),
+        (
+            "blabla/ 3.3.3.3 /blublu",
+            re.compile(r"^blabla/ ([^,]+) /blublu"),
+            "blabla/ 3.3.0.0 /blublu",
+            None,
+        ),
+        (
+            "1.1.1.1 - somefixedstring: 2.2.2.2 - some random stuff - 3.3.3.3",
+            re.compile(r"^([^,]+) - somefixedstring: ([^,]+) - .* - ([^,]+)"),
+            "1.1.0.0 - somefixedstring: 2.2.0.0 - some random stuff - 3.3.0.0",
+            None,
+        ),
+        (
+            "some line that doesn't match the provided regex",
+            re.compile(r"^([^,]+) - somefixedstring: ([^,]+) - .* - ([^,]+)"),
+            "some line that doesn't match the provided regex",
+            None,
+        ),
+        (
+            "match but no ip/ notanip /blublu",
+            re.compile(r"^match but no ip/ ([^,]+) /blublu"),
+            "match but no ip/ notanip /blublu",
+            None,
+        ),
+        (
+            "match but no ip/ notanip /blublu",
+            re.compile(r"^match but no ip/ ([^,]+) /blublu"),
+            "match but no ip/ yeah /blublu",
+            "yeah",
+        ),
+    ],
+)
+def test_regex(line, regex, expected, replace):
+    a = anonip.Anonip(regex=regex, replace=replace)
+    assert a.process_line(line) == expected
+
+
 def test_replace():
     a = anonip.Anonip(replace="replacement")
     assert a.process_line("bla something") == "replacement something"
@@ -179,6 +228,39 @@ def test_cli_generic_args(args, attribute, expected):
 
 
 @pytest.mark.parametrize(
+    "args,success",
+    [
+        ([], True),
+        (["--regex", "test"], True),
+        (["-c", "4"], True),
+        (["--regex", "test", "-c", "3"], False),
+        (["--regex", "test", "-l", ";"], False),
+        (["--regex", "test", "-l", ";", "-c", "4"], False),
+    ],
+)
+def test_cli_args_ambiguity(args, success):
+    if success:
+        anonip.parse_arguments(args)
+        return
+
+    with pytest.raises(SystemExit) as e:
+        anonip.parse_arguments(args)
+    assert e.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["--regex", "test"], "test"),
+        (["--regex", "foo", "bar", "baz"], "foo|bar|baz"),
+    ],
+)
+def test_regex_concat(args, expected):
+    args = anonip.parse_arguments(args)
+    assert args.regex == re.compile(expected)
+
+
+@pytest.mark.parametrize(
     "value,valid,bits",
     [
         ("1", True, 32),
@@ -205,6 +287,15 @@ def test_cli_validate_integer_ht_0(value, valid):
     else:
         with pytest.raises(argparse.ArgumentTypeError):
             anonip._validate_integer_ht_0(value)
+
+
+@pytest.mark.parametrize("value,valid", [("valid (.*)", True), ("\\9", False)])
+def test_regex_arg_type(value, valid):
+    if valid:
+        assert anonip.regex_arg_type(value) == value
+    else:
+        with pytest.raises(argparse.ArgumentTypeError):
+            anonip.regex_arg_type(value)
 
 
 @pytest.mark.parametrize("to_file", [False, True])


### PR DESCRIPTION
This commit implements regex based IP detection. This is intended to use
for logfiles where column based detection doesn't work.

See RFC (#44) for more information.

Closes #42, closes #44