### PR TITLE
chore: update supported python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        python: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", pypy3]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8]
+        python: [3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8]
+        python: [3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Using shell redirects, it's also possible to rewrite existing log files.
 ## Officially supported python versions
 
  - 2.7
- - 3.5
  - 3.6
  - 3.7
  - 3.8
+ - 3.9
+ - 3.10
 
 ## Dependencies
 If you're using python version >=3.3, there are no external

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # configuration options.
 
 [tox]
-envlist = py{27,35,36,37,38}, pypy3, flake8, black
+envlist = py{27,36,37,38,39,310}, pypy3, flake8, black
 
 [testenv]
 deps=


### PR DESCRIPTION
This commit drops support for python 3.5 and adds it for 3.9 and 3.10.